### PR TITLE
Cucumber::Chef::Config.test_config wants to be a class method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ gem "cucumber-nagios", ">= 0"
 gem "rspec", ">= 0"
 gem "fog", ">= 0"
 gem "thor", ">= 0"
+gem "awesome_print", ">= 0"
+gem "net-scp", ">= 0"
 
 group :development do
   gem "bundler", "~> 1.0.0"

--- a/lib/cucumber/chef/config.rb
+++ b/lib/cucumber/chef/config.rb
@@ -40,7 +40,7 @@ module Cucumber
         @config
       end
 
-      def test_config
+      def self.test_config
         config = self.new
         config[:mode] = "test"
         config


### PR DESCRIPTION
Various code attempts to call test_config as a class method, but it was defined as an instance method.

This pull request fixes the following test failures in spec/unit/config_spec.rb:
  2) Cucumber::Chef::Config when configuration is valid should provide a method for getting a test mode configuration
     Failure/Error: config = Cucumber::Chef::Config.test_config
     NoMethodError:
       undefined method `test_config' for Cucumber::Chef::Config:Class
     # ./spec/unit/config_spec.rb:103:in`block (3 levels) in <top (required)>'

  3) Cucumber::Chef::Config when configuration is valid should know it is in test mode
     Failure/Error: Cucumber::Chef::Config.test_config.test_mode?.should be
     NoMethodError:
       undefined method `test_config' for Cucumber::Chef::Config:Class
     # ./spec/unit/config_spec.rb:108:in`block (3 levels) in <top (required)>'
