### PR TITLE
Fix test failures in test_lab_spec.rb

### DIFF
--- a/lib/cucumber/chef/test_lab.rb
+++ b/lib/cucumber/chef/test_lab.rb
@@ -56,17 +56,15 @@ module Cucumber
       end
 
       def public_hostname
-        node.cloud.public_hostname
+        nodes.first.cloud.public_hostname
       end
 
-      def node
-        @node ||= begin
+      def nodes
         search = ::Chef::Search::Query.new
         mode = @config[:mode]
         query = "roles:test_lab_test AND tags:#{mode}"
         nodes, offset, total = search.search("node", URI.escape(query))
-        nodes.compact.first
-        end
+        nodes.compact
       end
 
       def running_labs

--- a/lib/cucumber/chef/test_lab.rb
+++ b/lib/cucumber/chef/test_lab.rb
@@ -52,7 +52,7 @@ module Cucumber
       end
 
       def info
-        "#{node.name}: #{node[:ec2][:public_ipv4]}"
+        running_labs.first.public_ip_address
       end
 
       def public_hostname

--- a/lib/cucumber/chef/test_lab.rb
+++ b/lib/cucumber/chef/test_lab.rb
@@ -38,12 +38,12 @@ module Cucumber
 
       def destroy
         running_labs.each do |server|
-          #server.destroy
-          puts server.public_ip_address
+          puts "Destroying Server: #{server.public_ip_address}"
+          server.destroy
         end
         nodes.each do |node|
+          puts "Not destroying Node: #{node[:ec2][:public_ipv4]}"
           # node.destroy
-          puts node[:ec2][:public_ipv4]
         end
       end
 


### PR DESCRIPTION
On master, tests in test_lab_spec are failing for various reasons - some due to apparent errors in the specs, others in the implementation.

This branch makes the following changes to the specs:
1. tcp_test_ssh() added, copied from provisioner_spec.rb
2. Don't attempt to invoke .run() on provisioner.bootstrap_node result

Additionally, the following changes are made to the implementation of TestLab:
1. .node() method (returning first node) changed to .nodes() (returning all nodes)
2. .destroy() method attempts to destroy the EC2 server
3. .info() method returns address of EC2 server, rather than the first chef node found

I'm unsure whether these fixes are correct:
- It seems odd that the implementation of .destroy() had commented out the call to terminate the EC2 instance - but this is necessary for the tests to pass.
- The change to .info() presumes that the implementation of the test is correct.
- The only remaining call to .node() was in .public_hostname() - its implementation has been changed to preserve previous behaviour.

All tests in test_lab_spec.rb pass with these changes in place, but I'm happy reworking anything which should have been solved differently.
