### PR TITLE
Removed cucumber-chef lines from gemspec, caused error with gem install.

### DIFF
--- a/cucumber-chef.gemspec
+++ b/cucumber-chef.gemspec
@@ -87,7 +87,6 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<cucumber-chef>, [">= 0"])
       s.add_runtime_dependency(%q<chef>, [">= 0.10.0"])
       s.add_runtime_dependency(%q<fog>, [">= 0"])
       s.add_runtime_dependency(%q<thor>, [">= 0"])
@@ -101,7 +100,6 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<jeweler>, ["~> 1.6.2"])
       s.add_development_dependency(%q<rcov>, [">= 0"])
     else
-      s.add_dependency(%q<cucumber-chef>, [">= 0"])
       s.add_dependency(%q<chef>, [">= 0.10.0"])
       s.add_dependency(%q<fog>, [">= 0"])
       s.add_dependency(%q<thor>, [">= 0"])
@@ -116,7 +114,6 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<rcov>, [">= 0"])
     end
   else
-    s.add_dependency(%q<cucumber-chef>, [">= 0"])
     s.add_dependency(%q<chef>, [">= 0.10.0"])
     s.add_dependency(%q<fog>, [">= 0"])
     s.add_dependency(%q<thor>, [">= 0"])


### PR DESCRIPTION
The lines of cucumber-chef as dependency in the gemspec was causing the creation of a new test lab to fail. Not sure if you would want to use the pull since it looked like from the commit this got generated from something else.
