### PR TITLE
Provision new security group when creating a test_lab.

### DIFF
--- a/lib/cucumber/chef/test_lab.rb
+++ b/lib/cucumber/chef/test_lab.rb
@@ -10,6 +10,11 @@ module Cucumber
                            :aws_access_key_id => @config[:knife][:aws_access_key_id],
                            :aws_secret_access_key => @config[:knife][:aws_secret_access_key],
                            :region => @config[:knife][:region])
+        @security_group = 'cucumber-chef'
+        unless @connection.security_groups.get(@security_group)
+          @connection.create_security_group(@security_group, 'cucumber-chef test lab')
+          @connection.security_groups.get(@security_group).authorize_port_range(22..22)
+        end
       end
 
       def build(output)
@@ -18,7 +23,7 @@ module Cucumber
         end
         server_definition = {
           :image_id => @config[:knife][:aws_image_id],
-          :groups => "default",
+          :groups => @security_group,
           :flavor_id => "m1.small",
           :key_name => @config[:knife][:aws_ssh_key_id],
           :availability_zone => @config[:knife][:availability_zone],


### PR DESCRIPTION
The default EC2 security group doesn't allow 22/tcp inbound.
This change creates a new security group "cucumber-chef" which does.

This should arguably remove the security group when "destroy" is called.
