### PR TITLE
fix "no such file to load -- cucumber/nagios/steps (LoadError)" on ubuntu 11.04

### DIFF
--- a/cookbooks/cucumber-chef/recipes/test_lab.rb
+++ b/cookbooks/cucumber-chef/recipes/test_lab.rb
@@ -2,7 +2,7 @@
   package pkg
 end
 
-%w[cucumber-chef rspec cucumber].each do |gem|
+%w[cucumber-chef rspec cucumber cucumber-nagios].each do |gem|
   gem_package gem
 end
 


### PR DESCRIPTION
```
$ cucumber-chef test example
Cucumber-chef project: example sucessfully uploaded to the test lab.
no such file to load -- cucumber/nagios/steps (LoadError)
/usr/local/lib/site_ruby/1.8/rubygems/custom_require.rb:31:in `gem_original_require'
/usr/local/lib/site_ruby/1.8/rubygems/custom_require.rb:31:in `require'
/home/ubuntu/example/features/support/env.rb:6
/usr/lib/ruby/gems/1.8/gems/cucumber-1.0.2/bin/../lib/cucumber/rb_support/rb_language.rb:143:in `load'
/usr/lib/ruby/gems/1.8/gems/cucumber-1.0.2/bin/../lib/cucumber/rb_support/rb_language.rb:143:in `load_code_file'
/usr/lib/ruby/gems/1.8/gems/cucumber-1.0.2/bin/../lib/cucumber/runtime/support_code.rb:176:in `load_file'
/usr/lib/ruby/gems/1.8/gems/cucumber-1.0.2/bin/../lib/cucumber/runtime/support_code.rb:78:in `load_files!'
/usr/lib/ruby/gems/1.8/gems/cucumber-1.0.2/bin/../lib/cucumber/runtime/support_code.rb:77:in `each'
/usr/lib/ruby/gems/1.8/gems/cucumber-1.0.2/bin/../lib/cucumber/runtime/support_code.rb:77:in `load_files!'
/usr/lib/ruby/gems/1.8/gems/cucumber-1.0.2/bin/../lib/cucumber/runtime.rb:137:in `load_step_definitions'
/usr/lib/ruby/gems/1.8/gems/cucumber-1.0.2/bin/../lib/cucumber/runtime.rb:39:in `run!'
/usr/lib/ruby/gems/1.8/gems/cucumber-1.0.2/bin/../lib/cucumber/cli/main.rb:43:in `execute!'
/usr/lib/ruby/gems/1.8/gems/cucumber-1.0.2/bin/../lib/cucumber/cli/main.rb:20:in `execute'
/usr/lib/ruby/gems/1.8/gems/cucumber-1.0.2/bin/cucumber:14
/usr/bin/cucumber:19:in `load'
/usr/bin/cucumber:19
```
