### PR TITLE
Two small changes to make cucumber-chef setup work with plain ubuntu 10.04 AMIs

### DIFF
--- a/cookbooks/cucumber-chef/recipes/controller.rb
+++ b/cookbooks/cucumber-chef/recipes/controller.rb
@@ -21,6 +21,8 @@ cookbook_file "/root/.bashrc" do
   source "add-git-identity"
 end
 
+directory "/etc/lxc"
+
 cookbook_file "/etc/lxc/controller" do
   source "lxc-controller-network-config"
 end

--- a/cookbooks/cucumber-chef/recipes/lxc.rb
+++ b/cookbooks/cucumber-chef/recipes/lxc.rb
@@ -23,7 +23,7 @@ mount "/cgroup" do
   action [:mount, :enable]
 end
 
-template "/usr/lib/lxc/templates/lxc-lucid-chef" do
+template "/usr/bin/lxc-lucid-chef" do
   source "lxc-lucid-chef"
   mode "0755"
   variables( :orgname => node["cucumber-chef"]["orgname"] )


### PR DESCRIPTION
1. The lxc-create script expects to find lxc-lucid-chef template in /usr/bin, not in /usr/lib/lxc/templates/
2. There is no directory /etc/lxc by default
