### PR TITLE
Deleted non existing TODO file from gemspec

### DIFF
--- a/cucumber-chef.gemspec
+++ b/cucumber-chef.gemspec
@@ -16,8 +16,7 @@ Gem::Specification.new do |s|
   s.executables = ["cucumber-chef"]
   s.extra_rdoc_files = [
     "LICENSE",
-    "README.md",
-    "TODO"
+    "README.md"
   ]
   s.files = [
     ".document",


### PR DESCRIPTION
Currently if you install the v1.0.4 from git using bundler, it tells:

cucumber-chef at did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["TODO"] are not files

and the binaries are not installed.

This patch fixes it.

Thanks,
Alexander Tamoykin
