### PR TITLE
Fixed conflicting knife -s param

### DIFF
--- a/bin/cc-knife
+++ b/bin/cc-knife
@@ -17,7 +17,7 @@ if (test_lab = Cucumber::Chef::TestLab.new) && (test_lab.labs_running.count > 0)
 
   knife_rb = Cucumber::Chef.locate(:file, ".cucumber-chef", "knife.rb")
   if File.exists?(knife_rb)
-    command = [knife, ARGV, "-s http://#{test_lab.labs_running.first.public_ip_address}:4000", "-c #{knife_rb}", "2>&1"].flatten.compact.join(" ")
+    command = [knife, ARGV, "--server-url http://#{test_lab.labs_running.first.public_ip_address}:4000", "--config #{knife_rb}", "2>&1"].flatten.compact.join(" ")
     puts(command)
     puts(%x(#{command}))
     exit($?.to_i)


### PR DESCRIPTION
When trying to use encrypted data bag secret file as follows:

```
$ cc-knife data bag from file api data_bags/api/repo.json --secret-file "keys/encrypted_data_bag_secret"
```

I was getting...

```
cc-knife v2.0.1.pre
/usr/bin/env knife data bag from file api data_bags/api/repo.json --secret-file keys/encrypted_data_bag_secret -s http://XXX.XXX.XXX.XXX:4000 -c /<my code dir>/chef-repo/.cucumber-chef/knife.rb 2>&1
FATAL: please specify only one of --secret, --secret-file
```

This was due to the shortened form of both "--secret" and "--server-url" of knife and its "data bag from file" subcommand being "-s".

Using the full param name fixes this.
