### PR TITLE
"persistent" is the correct spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,5 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+Foo

--- a/README.md
+++ b/README.md
@@ -40,5 +40,3 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-Foo

--- a/lib/cucumber/chef/steps/provision_steps.rb
+++ b/lib/cucumber/chef/steps/provision_steps.rb
@@ -31,7 +31,7 @@ And /^"([^\"]*)" has "([^\"]*)" architecture$/ do |name, arch|
   @servers[name].merge!( :arch => arch )
 end
 
-And /^"([^\"]*)" should( not)? be persistant$/ do |name, boolean|
+And /^"([^\"]*)" should( not)? be persist[ae]nt$/ do |name, boolean|
   @servers[name].merge!( :persist => (!boolean ? true : false) )
 end
 


### PR DESCRIPTION
We now accept "persistent" as well as "persistant"
