### PR TITLE
service "foo" is running

### DIFF
--- a/lib/cucumber/chef/steps/ssh_steps.rb
+++ b/lib/cucumber/chef/steps/ssh_steps.rb
@@ -94,17 +94,29 @@ Then /^I should( not)? see the "([^\"]*)" of "([^\"]*)" in the output$/ do |bool
   end
 end
 
-Then /^path "([^\"]*)" should exist$/ do |dir|
-  parent = File.dirname dir
-  child = File.basename dir
+Then /^(path|directory|file) "([^\"]*)" should exist$/ do |type, path|
+  parent = File.dirname path
+  child = File.basename path
   command = "ls %s" % [
     parent
   ]
   @output = @connection.exec!(command)
   @output.should =~ /#{child}/
+
+# if a specific type (directory|file) was specified, test for it
+  command = "stat -c %%F %s" % [
+    path
+  ]
+  @output = @connection.exec!(command)
+  if type == "file"
+    @output.should =~ /regular file/
+  end
+  if type == "directory"
+    @output.should =~ /directory/
+  end
 end
 
-Then /^path "([^\"]*)" should be owned by "([^\"]*)"$/ do |path, owner|
+Then /^(?:path|directory|file) "([^\"]*)" should be owned by "([^\"]*)"$/ do |path, owner|
   command = "stat -c %%U:%%G %s" % [
     path
   ]

--- a/lib/cucumber/chef/steps/ssh_steps.rb
+++ b/lib/cucumber/chef/steps/ssh_steps.rb
@@ -136,3 +136,25 @@ Then /^package "([^\"]*)" should be installed$/ do |package|
   @output = @connection.exec!(command)
   @output.should =~ /#{package}/
 end
+
+# This regex is a little ugly, but it's so we can accept any of these
+#
+# * "foo" is running
+# * service "foo" is running
+# * application "foo" is running
+# * process "foo" is running
+# 
+# basically because I couldn't decide what they should be called. Maybe there's
+# an Official Cucumber-chef Opinion on this. Still, Rubular is fun :)
+
+# TiL that in Ruby regexes, "?:" marks a non-capturing group, which is how this
+# works
+Then /^(?:(?:service|application|process)? )?"([^\"]*)" should( not)? be running$/ do |service, boolean|
+  command = "ps ax"
+  @output = @connection.exec!(command)
+  if (!boolean)
+    @output.should =~ /#{service}/
+  else
+    @output.should_not =~ /#{service}/
+  end
+end

--- a/lib/cucumber/chef/steps/ssh_steps.rb
+++ b/lib/cucumber/chef/steps/ssh_steps.rb
@@ -112,6 +112,8 @@ Then /^path "([^\"]*)" should be owned by "([^\"]*)"$/ do |path, owner|
   @output.should =~ /#{owner}/
 end
 
+# attempt at multiline match. Fail.
+#Then /^file "([^\"]*)" should( not)? contain\n? *(?:"")?"([^\"]*)"(?:"")?$/ do |path, boolean, content|
 Then /^file "([^\"]*)" should( not)? contain "([^\"]*)"$/ do |path, boolean, content|
   command = "cat %s" % [
     path

--- a/lib/cucumber/chef/steps/ssh_steps.rb
+++ b/lib/cucumber/chef/steps/ssh_steps.rb
@@ -94,7 +94,7 @@ Then /^I should( not)? see the "([^\"]*)" of "([^\"]*)" in the output$/ do |bool
   end
 end
 
-Then /^(path|directory|file) "([^\"]*)" should exist$/ do |type, path|
+Then /^(path|directory|file|symlink) "([^\"]*)" should exist$/ do |type, path|
   parent = File.dirname path
   child = File.basename path
   command = "ls %s" % [
@@ -108,12 +108,24 @@ Then /^(path|directory|file) "([^\"]*)" should exist$/ do |type, path|
     path
   ]
   @output = @connection.exec!(command)
-  if type == "file"
-    @output.should =~ /regular file/
+  types = {
+    "file" => /regular file/,
+    "directory" => /directory/,
+    "symlink" => /symbolic link/
+  }
+
+  if types.keys.include? type
+    @output.should =~ types[type]
   end
-  if type == "directory"
-    @output.should =~ /directory/
-  end
+#  if type == "file"
+#    @output.should =~ /regular file/
+#  end
+#  if type == "directory"
+#    @output.should =~ /directory/
+#  end
+#  if type == "symlink"
+#    @output.should =~ /symbolic link/
+#  end
 end
 
 Then /^(?:path|directory|file) "([^\"]*)" should be owned by "([^\"]*)"$/ do |path, owner|


### PR DESCRIPTION
So we can now do this
- "foo" is running
- service "foo" is running
- application "foo" is running
- process "foo" is running

for different formats because I couldn't decide what they should be called, and these all seem reasonable. Maybe there's an Official Cucumber-chef Opinion on this?
