### PR TITLE
Environment uploads

### DIFF
--- a/lib/cucumber/chef/helpers/chef_server.rb
+++ b/lib/cucumber/chef/helpers/chef_server.rb
@@ -62,6 +62,29 @@ module Cucumber::Chef::Helpers::ChefServer
 
 ################################################################################
 
+  def load_environment(environment, environment_path)
+    if !File.exists?(File.expand_path(environment_path))
+      raise "Environment path does not exist!"
+    end
+    ::Chef::Config[:environment_path] = environment_path
+    environment = ::Chef::Environment.json_create(
+      JSON.load(
+        File.open(
+          File.join( 
+            environment_path,
+            "%s.json" % [
+              environment
+            ]
+          )
+        )
+      )
+    )
+    environment.save
+    log("chef-server", "updated environment '#{environment}' from file '#{environment_path}'")
+ end
+
+################################################################################
+
   def create_databag(databag)
     @rest ||= ::Chef::REST.new(Chef::Config[:chef_server_url])
     @rest.post_rest("data", { "name" => databag })

--- a/lib/cucumber/chef/steps/chef_steps.rb
+++ b/lib/cucumber/chef/steps/chef_steps.rb
@@ -36,3 +36,9 @@ And /^the following cookbooks have been uploaded:$/ do |table|
     load_cookbook(entry['cookbook'], entry['cookbook_path'])
   end
 end
+
+And /^the following environments have been updated:$/ do |table|
+  table.hashes.each do |entry|
+    load_environment(entry['environment'], entry['environment_path'])
+  end
+end

--- a/lib/cucumber/chef/test_runner.rb
+++ b/lib/cucumber/chef/test_runner.rb
@@ -53,7 +53,20 @@ module Cucumber
         remote_path = File.join("/", "home", "ubuntu", "features")
         cucumber_options = args.flatten.compact.join(" ")
         env = ( destroy ? "DESTROY=1" : nil )
-        command = [ "cd #{remote_path}", "&&", "sudo", env, "cucumber", cucumber_options, "--exclude support/cookbooks", "--exclude support/roles", "--exclude support/data_bags", "--exclude support/keys", "." ].flatten.compact.join(" ")
+        command = [
+          "cd #{remote_path}",
+          "&&",
+          "sudo",
+          env,
+          "cucumber",
+          cucumber_options,
+          "--exclude support/cookbooks",
+          "--exclude support/roles",
+          "--exclude support/data_bags",
+          "--exclude support/keys",
+          "--exclude support/environments",
+          "."
+        ].flatten.compact.join(" ")
 
         @ssh.exec(command)
       end


### PR DESCRIPTION
We can now do this:

```
* the following environments have been updated:
  | environment | environment_path      |
  | production  | support/environments/ |
```

The environments have to be defined in json files called <environment>.json, like:

```
{
  "name": "production",
  "cookbook_versions": {
    "nodejs": "0.1.0"
  }
}
```

which is a little ugly, but I couldn't work out how to convert the regular .rb environment files into JSON. Does anybody know the best way to do this?
