### PR TITLE
Revert "pin a dependency on gherkin; don't let it go over 2.11.5 as that breaks JSON gem dependencies with Chef and a few other gems."

### DIFF
--- a/cucumber-chef.gemspec
+++ b/cucumber-chef.gemspec
@@ -43,7 +43,6 @@ Gem::Specification.new do |s|
 
   # TDD
   s.add_dependency("cucumber", ">= 1.2.0")
-  s.add_dependency("gherkin", "<= 2.11.5")
   s.add_dependency("rspec", ">= 2.10.0")
 
   # Support


### PR DESCRIPTION
This reverts commit 891b2ea849018273be3924a35619d93f4636926e.

Now that Chef is releasing updated versions of its gems (10.20.0 and 11.2.0), the gherkin requirement can be removed.

Vagrant's json requirement still conflicts, by the way, with Chef's json requirement. Vagrant will have to update their json restriction, I think.

vagrant.gemspec: `s.add_dependency "json", "~> 1.6.6"`
chef.gemspec: `s.add_dependency "json", ">= 1.4.4", "~> 1.7.6"`
