### PR TITLE
@output is now an OpenStruct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tmtags
 *.swp
 .rvmrc
 *gem
+.idea/

--- a/lib/cucumber/chef/steps/ssh_steps.rb
+++ b/lib/cucumber/chef/steps/ssh_steps.rb
@@ -177,8 +177,8 @@ Then /^package "([^\"]*)" should be installed$/ do |package|
 # could easily add more cases here, if I knew what they were :)
   end
 
-  @output = @connection.exec(command)
-  @output.should =~ /#{package}/
+  @output = @connection.exec(command, options = {:silence => true})
+  @output.output.should =~ /#{package}/
 end
 
 # This regex is a little ugly, but it's so we can accept any of these

--- a/lib/cucumber/chef/steps/ssh_steps.rb
+++ b/lib/cucumber/chef/steps/ssh_steps.rb
@@ -170,9 +170,9 @@ end
 
 Then /^package "([^\"]*)" should be installed$/ do |package|
   command = ""
-  if (dpkg = @connection.exec("which dpkg 2> /dev/null").output).length > 0
+  if (dpkg = @connection.exec("which dpkg 2> /dev/null", options = {:silence => true}).output).length > 0
     command = "#{dpkg.chomp} --get-selections"
-  elsif (yum = @connection.exec("which yum 2> /dev/null").output).length > 0
+  elsif (yum = @connection.exec("which yum 2> /dev/null", options = {:silence => true}).output).length > 0
     command = "#{yum.chomp} -q list installed"
 # could easily add more cases here, if I knew what they were :)
   end

--- a/lib/cucumber/chef/steps/ssh_steps.rb
+++ b/lib/cucumber/chef/steps/ssh_steps.rb
@@ -91,14 +91,14 @@ Then /^(path|directory|file|symlink) "([^\"]*)" should exist$/ do |type, path|
   command = "ls %s" % [
     parent
   ]
-  @output = @connection.exec(command, silence: true).output
+  @output = @connection.exec(command, :silence => true).output
   @output.should =~ /#{child}/
 
 # if a specific type (directory|file) was specified, test for it
   command = "stat -c %%F %s" % [
     path
   ]
-  @output = @connection.exec(command, silence: true).output
+  @output = @connection.exec(command, :silence => true).output
   types = {
     "file" => /regular file/,
     "directory" => /directory/,
@@ -168,7 +168,7 @@ Then /^package "([^\"]*)" should be installed$/ do |package|
 # could easily add more cases here, if I knew what they were :)
   end
 
-  @result = @connection.exec(command, silence: true)
+  @result = @connection.exec(command, :silence => true)
   @result.output.should =~ /#{package}/
 end
 

--- a/lib/cucumber/chef/steps/ssh_steps.rb
+++ b/lib/cucumber/chef/steps/ssh_steps.rb
@@ -91,14 +91,14 @@ Then /^(path|directory|file|symlink) "([^\"]*)" should exist$/ do |type, path|
   command = "ls %s" % [
     parent
   ]
-  @output = @connection.exec(command).output
+  @output = @connection.exec(command, silence: true).output
   @output.should =~ /#{child}/
 
 # if a specific type (directory|file) was specified, test for it
   command = "stat -c %%F %s" % [
     path
   ]
-  @output = @connection.exec(command).output
+  @output = @connection.exec(command, silence: true).output
   types = {
     "file" => /regular file/,
     "directory" => /directory/,
@@ -108,15 +108,6 @@ Then /^(path|directory|file|symlink) "([^\"]*)" should exist$/ do |type, path|
   if types.keys.include? type
     @output.should =~ types[type]
   end
-#  if type == "file"
-#    @output.should =~ /regular file/
-#  end
-#  if type == "directory"
-#    @output.should =~ /directory/
-#  end
-#  if type == "symlink"
-#    @output.should =~ /symbolic link/
-#  end
 end
 
 Then /^(?:path|directory|file) "([^\"]*)" should be owned by "([^\"]*)"$/ do |path, owner|

--- a/lib/cucumber/chef/steps/ssh_steps.rb
+++ b/lib/cucumber/chef/steps/ssh_steps.rb
@@ -170,15 +170,15 @@ end
 
 Then /^package "([^\"]*)" should be installed$/ do |package|
   command = ""
-  if (dpkg = @connection.exec("which dpkg 2> /dev/null", options = {:silence => true}).output).length > 0
+  if (dpkg = @connection.exec("which dpkg 2> /dev/null", silence: true).output).length > 0
     command = "#{dpkg.chomp} --get-selections"
-  elsif (yum = @connection.exec("which yum 2> /dev/null", options = {:silence => true}).output).length > 0
+  elsif (yum = @connection.exec("which yum 2> /dev/null", silence: true).output).length > 0
     command = "#{yum.chomp} -q list installed"
 # could easily add more cases here, if I knew what they were :)
   end
 
-  @output = @connection.exec(command, options = {:silence => true})
-  @output.output.should =~ /#{package}/
+  @result = @connection.exec(command, silence: true)
+  @result.output.should =~ /#{package}/
 end
 
 # This regex is a little ugly, but it's so we can accept any of these


### PR DESCRIPTION
where it used to be a string. This broke some of my old ssh_steps tests. I've now worked out what an OpenStruct actually is, and fixed the "package foo should be installed" assertion. I will fix up others as I hit them. There may be a case for some gentle refactoring somewhere down the road, but let's get this stuff working first.

Also, I've added the .idea/ directory from RubyMine to .gitngnore.
