### PR TITLE
tag aws servers with a Name

### DIFF
--- a/lib/cucumber/chef/providers/aws.rb
+++ b/lib/cucumber/chef/providers/aws.rb
@@ -222,6 +222,7 @@ module Cucumber
           {
             "cucumber-chef-mode" => Cucumber::Chef::Config.mode,
             "cucumber-chef-user" => Cucumber::Chef::Config.user,
+            "Name" => "cucumber-chef-#{Cucumber::Chef::Config.user}",
             "purpose" => "cucumber-chef"
           }.each do |k, v|
             tag = @connection.tags.new


### PR DESCRIPTION
When the `Name` tag is set, the AWS Web UI shows its value (instead of just `empty`). It's prettier =)
