### PR TITLE
Environments and Roles can be JSON as well as Ruby

### DIFF
--- a/lib/cucumber/chef/client.rb
+++ b/lib/cucumber/chef/client.rb
@@ -52,7 +52,8 @@ module Cucumber
 
         # Upload all of the chef-repo environments
         ZTK::Benchmark.bench(:message => ">>> Pushing chef-repo environments to the test lab", :mark => "completed in %0.4f seconds.") do
-          @test_lab.knife_cli(%(environment from file ./environments/*.rb ./environments/*.json), :silence => true)
+#          @test_lab.knife_cli(%(environment from file ./environments/*.rb ./environments/*.json), :silence => true)
+          @test_lab.knife_cli(%(environment from file `find environments | egrep "(json$|rb$)"`), :silence => true)
         end
 
         # Upload all of the chef-repo cookbooks
@@ -63,7 +64,8 @@ module Cucumber
 
         # Upload all of the chef-repo roles
         ZTK::Benchmark.bench(:message => ">>> Pushing chef-repo roles to the test lab", :mark => "completed in %0.4f seconds.") do
-          @test_lab.knife_cli(%(role from file ./roles/*.rb ./roles/*.json), :silence => true)
+#          @test_lab.knife_cli(%(role from file ./roles/*.rb ./roles/*.json), :silence => true)
+          @test_lab.knife_cli(%(role from file `find environments | egrep "(json$|rb$)"`), :silence => true)
         end
 
         # Upload all of our chef-repo data bags

--- a/lib/cucumber/chef/client.rb
+++ b/lib/cucumber/chef/client.rb
@@ -63,7 +63,7 @@ module Cucumber
 
         # Upload all of the chef-repo roles
         ZTK::Benchmark.bench(:message => ">>> Pushing chef-repo roles to the test lab", :mark => "completed in %0.4f seconds.") do
-          @test_lab.knife_cli(%(role from file ./roles/*.rb ./roles/*.rb), :silence => true)
+          @test_lab.knife_cli(%(role from file ./roles/*.rb ./roles/*.json), :silence => true)
         end
 
         # Upload all of our chef-repo data bags

--- a/lib/cucumber/chef/client.rb
+++ b/lib/cucumber/chef/client.rb
@@ -65,7 +65,7 @@ module Cucumber
         # Upload all of the chef-repo roles
         ZTK::Benchmark.bench(:message => ">>> Pushing chef-repo roles to the test lab", :mark => "completed in %0.4f seconds.") do
 #          @test_lab.knife_cli(%(role from file ./roles/*.rb ./roles/*.json), :silence => true)
-          @test_lab.knife_cli(%(role from file `find environments | egrep "(json$|rb$)"`), :silence => true)
+          @test_lab.knife_cli(%(role from file `find roles | egrep "(json$|rb$)"`), :silence => true)
         end
 
         # Upload all of our chef-repo data bags

--- a/lib/cucumber/chef/client.rb
+++ b/lib/cucumber/chef/client.rb
@@ -52,7 +52,7 @@ module Cucumber
 
         # Upload all of the chef-repo environments
         ZTK::Benchmark.bench(:message => ">>> Pushing chef-repo environments to the test lab", :mark => "completed in %0.4f seconds.") do
-          @test_lab.knife_cli(%(environment from file ./environments/*.rb), :silence => true)
+          @test_lab.knife_cli(%(environment from file ./environments/*.rb ./environments/*.json), :silence => true)
         end
 
         # Upload all of the chef-repo cookbooks
@@ -63,7 +63,7 @@ module Cucumber
 
         # Upload all of the chef-repo roles
         ZTK::Benchmark.bench(:message => ">>> Pushing chef-repo roles to the test lab", :mark => "completed in %0.4f seconds.") do
-          @test_lab.knife_cli(%(role from file ./roles/*.rb), :silence => true)
+          @test_lab.knife_cli(%(role from file ./roles/*.rb ./roles/*.rb), :silence => true)
         end
 
         # Upload all of our chef-repo data bags


### PR DESCRIPTION
I was attempting to use Etsy's rather nice [knife-spork](https://github.com/jonlives/knife-spork) tool, but it blew up because it expects environments as JSON, not as Ruby, so I changed the env in question over to JSON and then my cuke-chef runs started failing spectacularly because it was only uploading the *.rb envs.

Hence this. And it's also valid for a role to be JSON, too, of course.
